### PR TITLE
Add eventPosts (optionally)

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -11,8 +11,11 @@
 
 namespace Blomstra\FlagDuplicates;
 
+use Blomstra\FlagDuplicates\Post\DiscussionFlaggedAsDuplicatePost;
 use Flarum\Api\Controller\ShowDiscussionController;
 use Flarum\Extend;
+use Flarum\Flags\Event\Created as FlagCreated;
+use Flarum\Flags\Event\Deleting as FlagDeleting;
 use FoF\MergeDiscussions\Events\DiscussionWasMerged;
 
 return [
@@ -20,11 +23,19 @@ return [
         ->js(__DIR__.'/js/dist/forum.js')
         ->css(__DIR__.'/less/forum.less'),
 
+    (new Extend\Frontend('admin'))
+        ->js(__DIR__.'/js/dist/admin.js'),
+
     new Extend\Locales(__DIR__.'/locale'),
 
     (new Extend\ApiController(ShowDiscussionController::class))
         ->addInclude(['firstPost']),
 
     (new Extend\Event())
-        ->listen(DiscussionWasMerged::class, Listener\RemoveDuplicateFlagAfterMerge::class),
+        ->listen(DiscussionWasMerged::class, Listener\RemoveDuplicateFlagAfterMerge::class)
+        ->listen(FlagCreated::class, Listener\CreateDupeFlagRaisedPost::class)
+        ->listen(FlagDeleting::class, Listener\DeleteDupeFlagRaisedPost::class),
+
+    (new Extend\Post())
+        ->type(DiscussionFlaggedAsDuplicatePost::class),
 ];

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,1 @@
+export * from './src/admin';

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -1,0 +1,10 @@
+import app from 'flarum/admin/app';
+
+app.initializers.add('blomstra/flag-duplicates', () => {
+  app.extensionData.for('blomstra-flag-duplicates').registerSetting({
+    setting: 'blomstra-flag-duplicates.event_post',
+    type: 'boolean',
+    label: app.translator.trans('blomstra-flag-duplicates.admin.settings.event_post_label'),
+    help: app.translator.trans('blomstra-flag-duplicates.admin.settings.event_post_help'),
+  });
+});

--- a/js/src/forum/components/DiscussionFlaggedDuplicatePost.js
+++ b/js/src/forum/components/DiscussionFlaggedDuplicatePost.js
@@ -1,0 +1,41 @@
+import app from 'flarum/forum/app';
+import EventPost from 'flarum/components/EventPost';
+import LoadingIndicator from 'flarum/common/components/LoadingIndicator';
+import Link from 'flarum/common/components/Link';
+
+export default class DiscussionFlaggedDuplicatePost extends EventPost {
+  oninit(vnode) {
+    super.oninit(vnode);
+
+    this.loadDupe();
+  }
+
+  icon() {
+    return 'fas fa-flag';
+  }
+
+  descriptionKey() {
+    return 'blomstra-flag-duplicates.forum.post_stream.flagged_duplicate_text';
+  }
+
+  descriptionData() {
+    const data = {};
+
+    data.duplicate = this.dupe ? (
+      <Link href={app.route.discussion(this.dupe)}>{this.dupe.title()}</Link>
+    ) : (
+      <LoadingIndicator size="small" display="inline" />
+    );
+
+    return data;
+  }
+
+  loadDupe() {
+    const dupeId = this.attrs.post.content();
+    app.store.find('discussions', dupeId).then((discussion) => {
+      this.dupe = discussion;
+
+      m.redraw();
+    });
+  }
+}

--- a/js/src/forum/extendFlagModal.tsx
+++ b/js/src/forum/extendFlagModal.tsx
@@ -19,26 +19,28 @@ export default function extendFlagModal() {
   // https://github.com/flarum/flags/pull/39 is not available
   if (!FlagPostModal.prototype.flagReasons) {
     extend(FlagPostModal.prototype, 'content', function (this: FlagPostModal, vnode: Mithril.Vnode) {
-      if (this.attrs.post?.number() === 1) {
-        findFirstVdomChild(vnode, '.Form-group', (vnode) => {
-          const discussion = this.attrs.post.discussion();
+      if (this.attrs.post?.number() !== 1 || this.success) return;
 
-          vnode.children[0].children.splice(0, 0, <DiscussionSearch discussion={discussion} reason={this.reason} reasonDetail={this.reasonDetail} />);
-        });
-      }
+      findFirstVdomChild(vnode, '.Form-group', (vnode) => {
+        const discussion = this.attrs.post.discussion();
+
+        vnode.children[0].children.splice(0, 0, <DiscussionSearch discussion={discussion} reason={this.reason} reasonDetail={this.reasonDetail} />);
+      });
     });
   } else {
     extend(FlagPostModal.prototype, 'flagReasons', function (this: FlagPostModal, items: ItemList<Mithril.Children>) {
-      if (this.attrs.post?.number() === 1) {
-        const discussion = this.attrs.post.discussion();
+      if (this.attrs.post?.number() !== 1 || this.success) return;
 
-        items.add('duplicate', <DiscussionSearch discussion={discussion} reason={this.reason} reasonDetail={this.reasonDetail} />, 100);
-      }
+      const discussion = this.attrs.post.discussion();
+
+      items.add('duplicate', <DiscussionSearch discussion={discussion} reason={this.reason} reasonDetail={this.reasonDetail} />, 100);
     });
   }
 
   // Only required until https://github.com/flarum/core/pull/3260 is merged.
   extend(FlagPostModal.prototype, ['oncreate', 'onupdate'], function () {
+    if (this.attrs.post?.number() !== 1) return;
+
     this.$('.Search-clear').attr('type', 'button');
     this.$('.Button[type=submit]').prop('disabled', (this.reason() === 'duplicate' && !this.reasonDetail()) || !this.reason());
   });

--- a/js/src/forum/index.ts
+++ b/js/src/forum/index.ts
@@ -1,6 +1,8 @@
 import app from 'flarum/forum/app';
+import DiscussionFlaggedDuplicatePost from './components/DiscussionFlaggedDuplicatePost';
 import extendFlagModal from './extendFlagModal';
 
 app.initializers.add('blomstra/flag-duplicates', () => {
+  app.postComponents.discussionFlaggedDuplicate = DiscussionFlaggedDuplicatePost;
   extendFlagModal();
 });

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -4,6 +4,10 @@ flarum-flags:
       reason_duplicate_label: Duplicate
 
 blomstra-flag-duplicates:
+  admin:
+    settings:
+      event_post_help: Create an event post in the discussion where a "duplicate" flag has been raised. This can inform users that the discussion is potentially a duplicate of another, without giving them access to the overall flags which have been raised.
+      event_post_label: Event post
   forum:
     flags:
       duplicate_discussion: Duplicate discussion
@@ -11,3 +15,5 @@ blomstra-flag-duplicates:
       reason_duplicate_text: This discussion is a duplicate of another.
 
       deselect_discussion_a11y_label: Deselect discussion
+    post_stream:
+      flagged_duplicate_text: "{username} marked this discussion as a potential duplicate of {duplicate}. A moderator will investigate shortly."

--- a/src/Listener/CreateDupeFlagRaisedPost.php
+++ b/src/Listener/CreateDupeFlagRaisedPost.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of blomstra/flag-duplicates.
+ *
+ * Copyright (c) 2022 Blomstra Ltd.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Blomstra\FlagDuplicates\Listener;
+
+use Blomstra\FlagDuplicates\Post\DiscussionFlaggedAsDuplicatePost;
+use Flarum\Flags\Event\Created;
+use Flarum\Settings\SettingsRepositoryInterface;
+
+class CreateDupeFlagRaisedPost
+{
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+    
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+    }
+    
+    public function handle(Created $event)
+    {
+        $flag = $event->flag;
+
+        if ($flag->reason === 'duplicate' && (bool) $this->settings->get('blomstra-flag-duplicates.event_post', false)) {
+            $discussion = $flag->post->discussion;
+
+            $post = DiscussionFlaggedAsDuplicatePost::reply(
+                $discussion->id,
+                $event->actor->id,
+                $flag->reason_detail
+            );
+
+            $discussion->mergePost($post);
+        }
+    }
+}

--- a/src/Listener/CreateDupeFlagRaisedPost.php
+++ b/src/Listener/CreateDupeFlagRaisedPost.php
@@ -21,12 +21,12 @@ class CreateDupeFlagRaisedPost
      * @var SettingsRepositoryInterface
      */
     protected $settings;
-    
+
     public function __construct(SettingsRepositoryInterface $settings)
     {
         $this->settings = $settings;
     }
-    
+
     public function handle(Created $event)
     {
         $flag = $event->flag;

--- a/src/Listener/DeleteDupeFlagRaisedPost.php
+++ b/src/Listener/DeleteDupeFlagRaisedPost.php
@@ -25,9 +25,10 @@ class DeleteDupeFlagRaisedPost
             $flaggedPost = $flag->post;
             $discussion = $flaggedPost->discussion;
 
-            $eventPost = Post::where('discussion_id', $discussion->id)->where('type', 'discussionFlaggedDuplicate')->first();
+            $eventPosts = Post::where('discussion_id', $discussion->id)->where('type', 'discussionFlaggedDuplicate')->get();
 
-            if ($eventPost) {
+            foreach ($eventPosts as $eventPost) {
+                /** @var Post $eventPost */
                 $eventPost->delete();
             }
         }

--- a/src/Listener/DeleteDupeFlagRaisedPost.php
+++ b/src/Listener/DeleteDupeFlagRaisedPost.php
@@ -22,12 +22,12 @@ class DeleteDupeFlagRaisedPost
      * @var SettingsRepositoryInterface
      */
     protected $settings;
-    
+
     public function __construct(SettingsRepositoryInterface $settings)
     {
         $this->settings = $settings;
     }
-    
+
     public function handle(Deleting $event)
     {
         $flag = $event->flag;

--- a/src/Listener/DeleteDupeFlagRaisedPost.php
+++ b/src/Listener/DeleteDupeFlagRaisedPost.php
@@ -13,21 +13,10 @@ namespace Blomstra\FlagDuplicates\Listener;
 
 use Flarum\Flags\Event\Deleting;
 use Flarum\Post\Post;
-use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Support\Arr;
 
 class DeleteDupeFlagRaisedPost
 {
-    /**
-     * @var SettingsRepositoryInterface
-     */
-    protected $settings;
-
-    public function __construct(SettingsRepositoryInterface $settings)
-    {
-        $this->settings = $settings;
-    }
-
     public function handle(Deleting $event)
     {
         $flag = $event->flag;

--- a/src/Listener/DeleteDupeFlagRaisedPost.php
+++ b/src/Listener/DeleteDupeFlagRaisedPost.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of blomstra/flag-duplicates.
+ *
+ * Copyright (c) 2022 Blomstra Ltd.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Blomstra\FlagDuplicates\Listener;
+
+use Flarum\Flags\Event\Deleting;
+use Flarum\Post\Post;
+use Flarum\Settings\SettingsRepositoryInterface;
+use Illuminate\Support\Arr;
+
+class DeleteDupeFlagRaisedPost
+{
+    /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+    
+    public function __construct(SettingsRepositoryInterface $settings)
+    {
+        $this->settings = $settings;
+    }
+    
+    public function handle(Deleting $event)
+    {
+        $flag = $event->flag;
+
+        if ($flag->reason === 'duplicate' && Arr::get($event->data, 'duplicateMerge', false)) {
+            $flaggedPost = $flag->post;
+            $discussion = $flaggedPost->discussion;
+
+            $eventPost = Post::where('discussion_id', $discussion->id)->where('type', 'discussionFlaggedDuplicate')->first();
+
+            $eventPost->delete();
+        }
+    }
+}

--- a/src/Listener/DeleteDupeFlagRaisedPost.php
+++ b/src/Listener/DeleteDupeFlagRaisedPost.php
@@ -27,7 +27,9 @@ class DeleteDupeFlagRaisedPost
 
             $eventPost = Post::where('discussion_id', $discussion->id)->where('type', 'discussionFlaggedDuplicate')->first();
 
-            $eventPost->delete();
+            if ($eventPost) {
+                $eventPost->delete();
+            }
         }
     }
 }

--- a/src/Listener/RemoveDuplicateFlagAfterMerge.php
+++ b/src/Listener/RemoveDuplicateFlagAfterMerge.php
@@ -13,7 +13,6 @@ namespace Blomstra\FlagDuplicates\Listener;
 
 use Flarum\Flags\Event\Deleting;
 use Flarum\Flags\Flag;
-use Flarum\Post\Post;
 use FoF\MergeDiscussions\Events\DiscussionWasMerged;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Collection;
@@ -31,7 +30,7 @@ class RemoveDuplicateFlagAfterMerge
     public function handle(DiscussionWasMerged $event)
     {
         $discussion = $event->discussion;
-        
+
         $mergedDiscussions = $event->mergedDiscussions;
         $mergedDiscussionIds = $mergedDiscussions->pluck('id')->toArray();
 

--- a/src/Post/DiscussionFlaggedAsDuplicatePost.php
+++ b/src/Post/DiscussionFlaggedAsDuplicatePost.php
@@ -27,12 +27,12 @@ class DiscussionFlaggedAsDuplicatePost extends AbstractEventPost implements Merg
      */
     public function saveAfter(Post $previous = null)
     {
-        // If the previous post is another 'discussion tagged' post, and it's
+        // If the previous post is another 'discussion flagged dupe' post, and it's
         // by the same user, then we can merge this post into it. If we find
         // that we've in fact reverted the tag changes, delete it. Otherwise,
         // update its content.
         if ($previous instanceof static && $this->user_id === $previous->user_id) {
-            if ($previous->content[0] == $this->content[1]) {
+            if ($previous->content == $this->content) {
                 $previous->delete();
             } else {
                 $previous->content = static::buildContent($previous->content[0], $this->content[1]);
@@ -69,17 +69,4 @@ class DiscussionFlaggedAsDuplicatePost extends AbstractEventPost implements Merg
 
         return $post;
     }
-
-    /**
-     * Build the content attribute.
-     *
-     * @param array $oldTagIds
-     * @param array $newTagIds
-     *
-     * @return array
-     */
-    // public static function buildContent(array $oldTagIds, array $newTagIds)
-    // {
-    //     return [array_map('intval', $oldTagIds), array_map('intval', $newTagIds)];
-    // }
 }

--- a/src/Post/DiscussionFlaggedAsDuplicatePost.php
+++ b/src/Post/DiscussionFlaggedAsDuplicatePost.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of blomstra/flag-duplicates.
+ *
+ * Copyright (c) 2022 Blomstra Ltd.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+namespace Blomstra\FlagDuplicates\Post;
+
+use Flarum\Post\AbstractEventPost;
+use Flarum\Post\MergeableInterface;
+use Flarum\Post\Post;
+
+class DiscussionFlaggedAsDuplicatePost extends AbstractEventPost implements MergeableInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static $type = 'discussionFlaggedDuplicate';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveAfter(Post $previous = null)
+    {
+        // If the previous post is another 'discussion tagged' post, and it's
+        // by the same user, then we can merge this post into it. If we find
+        // that we've in fact reverted the tag changes, delete it. Otherwise,
+        // update its content.
+        if ($previous instanceof static && $this->user_id === $previous->user_id) {
+            if ($previous->content[0] == $this->content[1]) {
+                $previous->delete();
+            } else {
+                $previous->content = static::buildContent($previous->content[0], $this->content[1]);
+                $previous->created_at = $this->created_at;
+
+                $previous->save();
+            }
+
+            return $previous;
+        }
+
+        $this->save();
+
+        return $this;
+    }
+
+    /**
+     * Create a new instance in reply to a discussion.
+     *
+     * @param int $discussionId
+     * @param int $userId
+     * @param int $duplicateDiscussionId
+     * @return static
+     */
+    public static function reply($discussionId, $userId, $duplicateDiscussionId)
+    {
+        $post = new static;
+
+        $post->content = $duplicateDiscussionId;
+        $post->created_at = time();
+        $post->discussion_id = $discussionId;
+        $post->user_id = $userId;
+
+        return $post;
+    }
+
+    /**
+     * Build the content attribute.
+     *
+     * @param array $oldTagIds
+     * @param array $newTagIds
+     * @return array
+     */
+    // public static function buildContent(array $oldTagIds, array $newTagIds)
+    // {
+    //     return [array_map('intval', $oldTagIds), array_map('intval', $newTagIds)];
+    // }
+}

--- a/src/Post/DiscussionFlaggedAsDuplicatePost.php
+++ b/src/Post/DiscussionFlaggedAsDuplicatePost.php
@@ -55,11 +55,12 @@ class DiscussionFlaggedAsDuplicatePost extends AbstractEventPost implements Merg
      * @param int $discussionId
      * @param int $userId
      * @param int $duplicateDiscussionId
+     *
      * @return static
      */
     public static function reply($discussionId, $userId, $duplicateDiscussionId)
     {
-        $post = new static;
+        $post = new static();
 
         $post->content = $duplicateDiscussionId;
         $post->created_at = time();
@@ -74,6 +75,7 @@ class DiscussionFlaggedAsDuplicatePost extends AbstractEventPost implements Merg
      *
      * @param array $oldTagIds
      * @param array $newTagIds
+     *
      * @return array
      */
     // public static function buildContent(array $oldTagIds, array $newTagIds)


### PR DESCRIPTION
- extension setting (off by default) to create an `EventPost` after a user flags as a duplicate
- Remove the `EventPost` after merging
- Fix issue when "Merge into me" was used to perform the merge directly from the flag
